### PR TITLE
Change last WORKDIR to /usr/src/app in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN mkdir -p /usr/src/app/public/assets
 RUN mkdir -p /usr/src/app/tmp/sockets
 RUN mkdir -p /usr/src/app/tmp/pids
 
+WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 # Volumes


### PR DESCRIPTION
This fixes the app trying to run commands from the `/tmp` dir and failing.